### PR TITLE
Fix for PyInstaller

### DIFF
--- a/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_jit.py
+++ b/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_jit.py
@@ -18,7 +18,7 @@ __all__ = ['swish_jit', 'SwishJit', 'mish_jit', 'MishJit',
            'hard_sigmoid_jit', 'HardSigmoidJit', 'hard_swish_jit', 'HardSwishJit']
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def swish_jit(x, inplace: bool = False):
     """Swish - Described originally as SiLU (https://arxiv.org/abs/1702.03118v3)
     and also as Swish (https://arxiv.org/abs/1710.05941).
@@ -28,7 +28,7 @@ def swish_jit(x, inplace: bool = False):
     return x.mul(x.sigmoid())
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def mish_jit(x, _inplace: bool = False):
     """Mish: A Self Regularized Non-Monotonic Neural Activation Function - https://arxiv.org/abs/1908.08681
     """
@@ -51,7 +51,7 @@ class MishJit(nn.Module):
         return mish_jit(x)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def hard_sigmoid_jit(x, inplace: bool = False):
     # return F.relu6(x + 3.) / 6.
     return (x + 3).clamp(min=0, max=6).div(6.)  # clamp seems ever so slightly faster?
@@ -65,7 +65,7 @@ class HardSigmoidJit(nn.Module):
         return hard_sigmoid_jit(x)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def hard_swish_jit(x, inplace: bool = False):
     # return x * (F.relu6(x + 3.) / 6)
     return x * (x + 3).clamp(min=0, max=6).div(6.)  # clamp seems ever so slightly faster?

--- a/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_jit.py
+++ b/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_jit.py
@@ -18,7 +18,7 @@ __all__ = ['swish_jit', 'SwishJit', 'mish_jit', 'MishJit',
            'hard_sigmoid_jit', 'HardSigmoidJit', 'hard_swish_jit', 'HardSwishJit']
 
 
-@torch.jit.script
+@torch.jit.trace
 def swish_jit(x, inplace: bool = False):
     """Swish - Described originally as SiLU (https://arxiv.org/abs/1702.03118v3)
     and also as Swish (https://arxiv.org/abs/1710.05941).
@@ -28,7 +28,7 @@ def swish_jit(x, inplace: bool = False):
     return x.mul(x.sigmoid())
 
 
-@torch.jit.script
+@torch.jit.trace
 def mish_jit(x, _inplace: bool = False):
     """Mish: A Self Regularized Non-Monotonic Neural Activation Function - https://arxiv.org/abs/1908.08681
     """
@@ -51,7 +51,7 @@ class MishJit(nn.Module):
         return mish_jit(x)
 
 
-@torch.jit.script
+@torch.jit.trace
 def hard_sigmoid_jit(x, inplace: bool = False):
     # return F.relu6(x + 3.) / 6.
     return (x + 3).clamp(min=0, max=6).div(6.)  # clamp seems ever so slightly faster?
@@ -65,7 +65,7 @@ class HardSigmoidJit(nn.Module):
         return hard_sigmoid_jit(x)
 
 
-@torch.jit.script
+@torch.jit.trace
 def hard_swish_jit(x, inplace: bool = False):
     # return x * (F.relu6(x + 3.) / 6)
     return x * (x + 3).clamp(min=0, max=6).div(6.)  # clamp seems ever so slightly faster?

--- a/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_me.py
+++ b/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_me.py
@@ -18,19 +18,19 @@ __all__ = ['swish_me', 'SwishMe', 'mish_me', 'MishMe',
            'hard_sigmoid_me', 'HardSigmoidMe', 'hard_swish_me', 'HardSwishMe']
 
 
-@torch.jit.script
+@torch.jit.trace
 def swish_jit_fwd(x):
     return x.mul(torch.sigmoid(x))
 
 
-@torch.jit.script
+@torch.jit.trace
 def swish_jit_bwd(x, grad_output):
     x_sigmoid = torch.sigmoid(x)
     return grad_output * (x_sigmoid * (1 + x * (1 - x_sigmoid)))
 
 
 class SwishJitAutoFn(torch.autograd.Function):
-    """ torch.jit.script optimised Swish w/ memory-efficient checkpoint
+    """ torch.jit.trace optimised Swish w/ memory-efficient checkpoint
     Inspired by conversation btw Jeremy Howard & Adam Pazske
     https://twitter.com/jeremyphoward/status/1188251041835315200
 
@@ -63,12 +63,12 @@ class SwishMe(nn.Module):
         return SwishJitAutoFn.apply(x)
 
 
-@torch.jit.script
+@torch.jit.trace
 def mish_jit_fwd(x):
     return x.mul(torch.tanh(F.softplus(x)))
 
 
-@torch.jit.script
+@torch.jit.trace
 def mish_jit_bwd(x, grad_output):
     x_sigmoid = torch.sigmoid(x)
     x_tanh_sp = F.softplus(x).tanh()
@@ -102,12 +102,12 @@ class MishMe(nn.Module):
         return MishJitAutoFn.apply(x)
 
 
-@torch.jit.script
+@torch.jit.trace
 def hard_sigmoid_jit_fwd(x, inplace: bool = False):
     return (x + 3).clamp(min=0, max=6).div(6.)
 
 
-@torch.jit.script
+@torch.jit.trace
 def hard_sigmoid_jit_bwd(x, grad_output):
     m = torch.ones_like(x) * ((x >= -3.) & (x <= 3.)) / 6.
     return grad_output * m
@@ -137,12 +137,12 @@ class HardSigmoidMe(nn.Module):
         return HardSigmoidJitAutoFn.apply(x)
 
 
-@torch.jit.script
+@torch.jit.trace
 def hard_swish_jit_fwd(x):
     return x * (x + 3).clamp(min=0, max=6).div(6.)
 
 
-@torch.jit.script
+@torch.jit.trace
 def hard_swish_jit_bwd(x, grad_output):
     m = torch.ones_like(x) * (x >= 3.)
     m = torch.where((x >= -3.) & (x <= 3.),  x / 3. + .5, m)

--- a/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_me.py
+++ b/src/controlnet_aux/normalbae/nets/submodules/efficientnet_repo/geffnet/activations/activations_me.py
@@ -18,19 +18,19 @@ __all__ = ['swish_me', 'SwishMe', 'mish_me', 'MishMe',
            'hard_sigmoid_me', 'HardSigmoidMe', 'hard_swish_me', 'HardSwishMe']
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def swish_jit_fwd(x):
     return x.mul(torch.sigmoid(x))
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def swish_jit_bwd(x, grad_output):
     x_sigmoid = torch.sigmoid(x)
     return grad_output * (x_sigmoid * (1 + x * (1 - x_sigmoid)))
 
 
 class SwishJitAutoFn(torch.autograd.Function):
-    """ torch.jit.trace optimised Swish w/ memory-efficient checkpoint
+    """ torch.jit.script_if_tracing optimised Swish w/ memory-efficient checkpoint
     Inspired by conversation btw Jeremy Howard & Adam Pazske
     https://twitter.com/jeremyphoward/status/1188251041835315200
 
@@ -63,12 +63,12 @@ class SwishMe(nn.Module):
         return SwishJitAutoFn.apply(x)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def mish_jit_fwd(x):
     return x.mul(torch.tanh(F.softplus(x)))
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def mish_jit_bwd(x, grad_output):
     x_sigmoid = torch.sigmoid(x)
     x_tanh_sp = F.softplus(x).tanh()
@@ -102,12 +102,12 @@ class MishMe(nn.Module):
         return MishJitAutoFn.apply(x)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def hard_sigmoid_jit_fwd(x, inplace: bool = False):
     return (x + 3).clamp(min=0, max=6).div(6.)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def hard_sigmoid_jit_bwd(x, grad_output):
     m = torch.ones_like(x) * ((x >= -3.) & (x <= 3.)) / 6.
     return grad_output * m
@@ -137,12 +137,12 @@ class HardSigmoidMe(nn.Module):
         return HardSigmoidJitAutoFn.apply(x)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def hard_swish_jit_fwd(x):
     return x * (x + 3).clamp(min=0, max=6).div(6.)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def hard_swish_jit_bwd(x, grad_output):
     m = torch.ones_like(x) * (x >= 3.)
     m = torch.where((x >= -3.) & (x <= 3.),  x / 3. + .5, m)

--- a/src/controlnet_aux/zoe/zoedepth/models/layers/attractor.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/layers/attractor.py
@@ -26,7 +26,7 @@ import torch
 import torch.nn as nn
 
 
-@torch.jit.script
+@torch.jit.trace
 def exp_attractor(dx, alpha: float = 300, gamma: int = 2):
     """Exponential attractor: dc = exp(-alpha*|dx|^gamma) * dx , where dx = a - c, a = attractor point, c = bin center, dc = shift in bin centermmary for exp_attractor
 
@@ -41,7 +41,7 @@ def exp_attractor(dx, alpha: float = 300, gamma: int = 2):
     return torch.exp(-alpha*(torch.abs(dx)**gamma)) * (dx)
 
 
-@torch.jit.script
+@torch.jit.trace
 def inv_attractor(dx, alpha: float = 300, gamma: int = 2):
     """Inverse attractor: dc = dx / (1 + alpha*dx^gamma), where dx = a - c, a = attractor point, c = bin center, dc = shift in bin center
     This is the default one according to the accompanying paper. 

--- a/src/controlnet_aux/zoe/zoedepth/models/layers/attractor.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/layers/attractor.py
@@ -26,7 +26,7 @@ import torch
 import torch.nn as nn
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def exp_attractor(dx, alpha: float = 300, gamma: int = 2):
     """Exponential attractor: dc = exp(-alpha*|dx|^gamma) * dx , where dx = a - c, a = attractor point, c = bin center, dc = shift in bin centermmary for exp_attractor
 
@@ -41,7 +41,7 @@ def exp_attractor(dx, alpha: float = 300, gamma: int = 2):
     return torch.exp(-alpha*(torch.abs(dx)**gamma)) * (dx)
 
 
-@torch.jit.trace
+@torch.jit.script_if_tracing
 def inv_attractor(dx, alpha: float = 300, gamma: int = 2):
     """Inverse attractor: dc = dx / (1 + alpha*dx^gamma), where dx = a - c, a = attractor point, c = bin center, dc = shift in bin center
     This is the default one according to the accompanying paper. 


### PR DESCRIPTION
This dependency doesn't work with PyInstaller, with error:
```
TorchScript requires source access in order to carry out compilation, make sure original .py files are available.
```

The solution is to replace `torch.jit.script` with `torch.jit.script_if_tracing`. 