### PR TITLE
Prevent Zoe Depth error by restricting timm version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,9 +86,9 @@ _deps = [
     "scipy",
     "huggingface_hub",
     "einops",
-    "timm",
+    "timm<=0.6.7",
     "torchvision",
-    "scikit-image"
+    "scikit-image",
 ]
 
 # this is a lookup table with items like:


### PR DESCRIPTION
If `timm` is installed with a version above `0.6.7`, loading the Zoe Depth checkpoint throws an error.

Related issue: https://github.com/isl-org/ZoeDepth/issues/97