### PR TITLE
Fix pidi models ability to run on non primary gpu

### DIFF
--- a/src/controlnet_aux/pidi/model.py
+++ b/src/controlnet_aux/pidi/model.py
@@ -330,10 +330,7 @@ def createConvFunc(op_type):
             padding = 2 * dilation
 
             shape = weights.shape
-            if weights.is_cuda:
-                buffer = torch.cuda.FloatTensor(shape[0], shape[1], 5 * 5).fill_(0)
-            else:
-                buffer = torch.zeros(shape[0], shape[1], 5 * 5).to(weights.device)
+            buffer = torch.zeros(shape[0], shape[1], 5 * 5).to(weights.device)
             weights = weights.view(shape[0], shape[1], -1)
             buffer[:, :, [0, 2, 4, 10, 14, 20, 22, 24]] = weights[:, :, 1:]
             buffer[:, :, [6, 7, 8, 11, 13, 16, 17, 18]] = -weights[:, :, 1:]


### PR DESCRIPTION
The PidiNet detector cannot run on any other GPU aside from GPU 0 due always initializing a specific tensor on the first available GPU.

Changing this line of code so that the tensor is created on the correct GPU fixes the issue and allows PidiNet to run on a device other than the primary GPU.