### PR TITLE
Pidi device assignment / timm compatibility fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ _deps = [
     "scipy",
     "huggingface_hub",
     "einops",
-    "timm<=0.6.7",
+    "timm",
     "torchvision",
     "scikit-image",
 ]

--- a/src/controlnet_aux/leres/leres/net_tools.py
+++ b/src/controlnet_aux/leres/leres/net_tools.py
@@ -18,6 +18,10 @@ def get_func(func_name):
             return globals()[parts[0]]
         # Otherwise, assume we're referencing a module under modeling
         module_name = '.' + '.'.join(parts[:-1])
+
+        # Import module_name, for example ".network_auxi",
+        # under __package__=="controlnet_aux.leres.leres"
+        # __package__ resolves to the package namespace above this file
         module = importlib.import_module(module_name, package=__package__)
         return getattr(module, parts[-1])
     except Exception:

--- a/src/controlnet_aux/leres/leres/net_tools.py
+++ b/src/controlnet_aux/leres/leres/net_tools.py
@@ -17,8 +17,8 @@ def get_func(func_name):
         if len(parts) == 1:
             return globals()[parts[0]]
         # Otherwise, assume we're referencing a module under modeling
-        module_name = 'controlnet_aux.leres.leres.' + '.'.join(parts[:-1])
-        module = importlib.import_module(module_name)
+        module_name = '.' + '.'.join(parts[:-1])
+        module = importlib.import_module(module_name, package=__package__)
         return getattr(module, parts[-1])
     except Exception:
         print('Failed to f1ind function: %s', func_name)

--- a/src/controlnet_aux/leres/pix2pix/models/__init__.py
+++ b/src/controlnet_aux/leres/pix2pix/models/__init__.py
@@ -30,6 +30,10 @@ def find_model_using_name(model_name):
     and it is case-insensitive.
     """
     model_filename = "." + model_name + "_model"
+
+    # Import model_filename, for example ".pix2pix4depth_model",
+    # under __package__=="controlnet_aux.leres.pix2pix.models"
+    # __package__ resolves to the package namespace above this file
     modellib = importlib.import_module(model_filename, package=__package__)
     model = None
     target_model_name = model_name.replace('_', '') + 'model'

--- a/src/controlnet_aux/leres/pix2pix/models/__init__.py
+++ b/src/controlnet_aux/leres/pix2pix/models/__init__.py
@@ -29,8 +29,8 @@ def find_model_using_name(model_name):
     be instantiated. It has to be a subclass of BaseModel,
     and it is case-insensitive.
     """
-    model_filename = "controlnet_aux.leres.pix2pix.models." + model_name + "_model"
-    modellib = importlib.import_module(model_filename)
+    model_filename = "." + model_name + "_model"
+    modellib = importlib.import_module(model_filename, package=__package__)
     model = None
     target_model_name = model_name.replace('_', '') + 'model'
     for name, cls in modellib.__dict__.items():

--- a/src/controlnet_aux/pidi/model.py
+++ b/src/controlnet_aux/pidi/model.py
@@ -330,10 +330,7 @@ def createConvFunc(op_type):
             padding = 2 * dilation
 
             shape = weights.shape
-            if weights.is_cuda:
-                buffer = torch.cuda.FloatTensor(shape[0], shape[1], 5 * 5).fill_(0)
-            else:
-                buffer = torch.zeros(shape[0], shape[1], 5 * 5).to(weights.device)
+            buffer = torch.zeros(shape[0], shape[1], 5 * 5).to(weights.device)
             weights = weights.view(shape[0], shape[1], -1)
             buffer[:, :, [0, 2, 4, 10, 14, 20, 22, 24]] = weights[:, :, 1:]
             buffer[:, :, [6, 7, 8, 11, 13, 16, 17, 18]] = -weights[:, :, 1:]

--- a/src/controlnet_aux/zoe/__init__.py
+++ b/src/controlnet_aux/zoe/__init__.py
@@ -35,7 +35,7 @@ class ZoeDetector:
             model.load_state_dict(state_dict)
         except RuntimeError as e:
             # If that fails, try loading with strict=False
-            # print(f"Warning: Standard model loading failed, trying with strict=False: {str(e)}")
+            print(f"Warning: Standard model loading failed, trying with strict=False: {str(e)}")
             state_dict = torch.load(model_path, map_location=torch.device('cpu'))['model']
             model.load_state_dict(state_dict, strict=False)
             

--- a/src/controlnet_aux/zoe/__init__.py
+++ b/src/controlnet_aux/zoe/__init__.py
@@ -29,7 +29,16 @@ class ZoeDetector:
         conf = get_config(model_type, "infer")
         model_cls = ZoeDepth if model_type == "zoedepth" else ZoeDepthNK
         model = model_cls.build_from_config(conf)
-        model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu'))['model'])
+        try:
+            # Try to load the model with standard approach first
+            state_dict = torch.load(model_path, map_location=torch.device('cpu'))['model']
+            model.load_state_dict(state_dict)
+        except RuntimeError as e:
+            # If that fails, try loading with strict=False
+            # print(f"Warning: Standard model loading failed, trying with strict=False: {str(e)}")
+            state_dict = torch.load(model_path, map_location=torch.device('cpu'))['model']
+            model.load_state_dict(state_dict, strict=False)
+            
         model.eval()
 
         return cls(model)

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/levit.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/levit.py
@@ -1,7 +1,7 @@
-import timm
 import torch
 import torch.nn as nn
 import numpy as np
+from .timm_adapter import create_model_adapter
 
 from .utils import activations, get_activation, Transpose
 
@@ -97,7 +97,7 @@ def stem_b4_transpose(in_chs, out_chs, activation):
 
 
 def _make_pretrained_levit_384(pretrained, hooks=None):
-    model = timm.create_model("levit_384", pretrained=pretrained)
+    model = create_model_adapter("levit_384", pretrained=pretrained)
 
     hooks = [3, 11, 21] if hooks == None else hooks
     return _make_levit_backbone(

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/next_vit.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/next_vit.py
@@ -1,6 +1,5 @@
-import timm
-
 import torch.nn as nn
+from .timm_adapter import create_model_adapter
 
 from pathlib import Path
 from .utils import activations, forward_default, get_activation
@@ -30,7 +29,7 @@ def _make_next_vit_backbone(
 
 
 def _make_pretrained_next_vit_large_6m(hooks=None):
-    model = timm.create_model("nextvit_large")
+    model = create_model_adapter("nextvit_large")
 
     hooks = [2, 6, 36, 39] if hooks == None else hooks
     return _make_next_vit_backbone(

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/swin.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/swin.py
@@ -1,10 +1,9 @@
-import timm
-
+from .timm_adapter import create_model_adapter
 from .swin_common import _make_swin_backbone
 
 
 def _make_pretrained_swinl12_384(pretrained, hooks=None):
-    model = timm.create_model("swin_large_patch4_window12_384", pretrained=pretrained)
+    model = create_model_adapter("swin_large_patch4_window12_384", pretrained=pretrained)
 
     hooks = [1, 1, 17, 1] if hooks == None else hooks
     return _make_swin_backbone(

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/swin2.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/swin2.py
@@ -1,10 +1,9 @@
-import timm
-
+from .timm_adapter import create_model_adapter
 from .swin_common import _make_swin_backbone
 
 
 def _make_pretrained_swin2l24_384(pretrained, hooks=None):
-    model = timm.create_model("swinv2_large_window12to24_192to384_22kft1k", pretrained=pretrained)
+    model = create_model_adapter("swinv2_large_window12to24_192to384_22kft1k", pretrained=pretrained)
 
     hooks = [1, 1, 17, 1] if hooks == None else hooks
     return _make_swin_backbone(
@@ -14,7 +13,7 @@ def _make_pretrained_swin2l24_384(pretrained, hooks=None):
 
 
 def _make_pretrained_swin2b24_384(pretrained, hooks=None):
-    model = timm.create_model("swinv2_base_window12to24_192to384_22kft1k", pretrained=pretrained)
+    model = create_model_adapter("swinv2_base_window12to24_192to384_22kft1k", pretrained=pretrained)
 
     hooks = [1, 1, 17, 1] if hooks == None else hooks
     return _make_swin_backbone(
@@ -24,7 +23,7 @@ def _make_pretrained_swin2b24_384(pretrained, hooks=None):
 
 
 def _make_pretrained_swin2t16_256(pretrained, hooks=None):
-    model = timm.create_model("swinv2_tiny_window16_256", pretrained=pretrained)
+    model = create_model_adapter("swinv2_tiny_window16_256", pretrained=pretrained)
 
     hooks = [1, 1, 5, 1] if hooks == None else hooks
     return _make_swin_backbone(

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/timm_adapter.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/timm_adapter.py
@@ -1,0 +1,20 @@
+import importlib.metadata
+import timm
+
+# Check the installed timm version
+timm_version = importlib.metadata.version("timm")
+is_new_timm = timm_version >= "1.0.0"
+
+def create_model_adapter(model_name, pretrained=False, **kwargs):
+    """
+    Adapter function for creating models with timm that works with both old (0.6.7) and new (1.0+) versions.
+    """
+    if is_new_timm:
+        # In timm 1.0+, 'pretrained' is deprecated in favor of 'pretrained_cfg' or explicit pretrained_cfg_url
+        if pretrained:
+            return timm.create_model(model_name, pretrained_cfg='default', **kwargs)
+        else:
+            return timm.create_model(model_name, pretrained_cfg=None, **kwargs)
+    else:
+        # Old timm behavior
+        return timm.create_model(model_name, pretrained=pretrained, **kwargs) 

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/utils.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/utils.py
@@ -1,6 +1,8 @@
 import torch
-
 import torch.nn as nn
+
+# Store activations
+activations = {}
 
 
 class Slice(nn.Module):
@@ -50,12 +52,25 @@ class Transpose(nn.Module):
         return x
 
 
-activations = {}
+def get_drop_path(module):
+    """Helper function to get the drop_path attribute from a module, handling
+    different attribute names between timm versions"""
+    if hasattr(module, 'drop_path'):
+        return module.drop_path
+    elif hasattr(module, 'drop_path1'):
+        return module.drop_path1
+    else:
+        # Return identity function if drop_path doesn't exist
+        return lambda x: x
 
 
-def get_activation(name):
+def get_activation(name, bank=None):
+    """Returns a function that extracts activations of specified name from given bank"""
+    if bank is None:
+        bank = activations
+
     def hook(model, input, output):
-        activations[name] = output
+        bank[name] = output
 
     return hook
 

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/vit.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/vit.py
@@ -1,9 +1,9 @@
 import torch
 import torch.nn as nn
-import timm
 import types
 import math
 import torch.nn.functional as F
+from .timm_adapter import create_model_adapter
 
 from .utils import (activations, forward_adapted_unflatten, get_activation, get_readout_oper,
                     make_backbone_default, Transpose)
@@ -64,7 +64,10 @@ def forward_flex(self, x):
         x = x + pos_embed
     x = self.pos_drop(x)
 
-    for blk in self.blocks:
+    # Handle different blocks attribute naming in different timm versions
+    blocks = self.blocks if hasattr(self, 'blocks') else self.transformer.blocks
+    
+    for blk in blocks:
         x = blk(x)
 
     x = self.norm(x)
@@ -96,7 +99,7 @@ def _make_vit_b16_backbone(
 
 
 def _make_pretrained_vitl16_384(pretrained, use_readout="ignore", hooks=None):
-    model = timm.create_model("vit_large_patch16_384", pretrained=pretrained)
+    model = create_model_adapter("vit_large_patch16_384", pretrained=pretrained)
 
     hooks = [5, 11, 17, 23] if hooks == None else hooks
     return _make_vit_b16_backbone(
@@ -109,7 +112,7 @@ def _make_pretrained_vitl16_384(pretrained, use_readout="ignore", hooks=None):
 
 
 def _make_pretrained_vitb16_384(pretrained, use_readout="ignore", hooks=None):
-    model = timm.create_model("vit_base_patch16_384", pretrained=pretrained)
+    model = create_model_adapter("vit_base_patch16_384", pretrained=pretrained)
 
     hooks = [2, 5, 8, 11] if hooks == None else hooks
     return _make_vit_b16_backbone(
@@ -208,7 +211,7 @@ def _make_vit_b_rn50_backbone(
 def _make_pretrained_vitb_rn50_384(
     pretrained, use_readout="ignore", hooks=None, use_vit_only=False
 ):
-    model = timm.create_model("vit_base_resnet50_384", pretrained=pretrained)
+    model = create_model_adapter("vit_base_resnet50_384", pretrained=pretrained)
 
     hooks = [0, 1, 8, 11] if hooks == None else hooks
     return _make_vit_b_rn50_backbone(

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/dpt_depth.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/dpt_depth.py
@@ -197,4 +197,4 @@ class DPTDepthModel(DPT):
                 return out.squeeze(dim=1)
             else:
                 # If it's not a known compatibility issue, re-raise
-                raise
+                raise e

--- a/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/dpt_depth.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/base_models/midas_repo/midas/dpt_depth.py
@@ -163,4 +163,38 @@ class DPTDepthModel(DPT):
            self.load(path)
 
     def forward(self, x):
-        return super().forward(x).squeeze(dim=1)
+        """Forward pass.
+
+        Args:
+            x (tensor): input data (image)
+
+        Returns:
+            tensor: depth
+        """
+        try:
+            # Standard forward pass
+            return super().forward(x).squeeze(dim=1)
+        except (AttributeError, RuntimeError) as e:
+            # Handle compatibility issues
+            if "drop_path" in str(e):
+                # print("Warning: Handling timm compatibility issue. Using alternative forward path.")
+                # Manual forward implementation as fallback
+                layers = self.forward_transformer(self.pretrained, x)
+                layer_1, layer_2, layer_3, layer_4 = layers
+                
+                layer_1_rn = self.scratch.layer1_rn(layer_1)
+                layer_2_rn = self.scratch.layer2_rn(layer_2)
+                layer_3_rn = self.scratch.layer3_rn(layer_3)
+                layer_4_rn = self.scratch.layer4_rn(layer_4)
+                
+                path_4 = self.scratch.refinenet4(layer_4_rn)
+                path_3 = self.scratch.refinenet3(path_4, layer_3_rn)
+                path_2 = self.scratch.refinenet2(path_3, layer_2_rn)
+                path_1 = self.scratch.refinenet1(path_2, layer_1_rn)
+                
+                out = self.scratch.output_conv(path_1)
+                
+                return out.squeeze(dim=1)
+            else:
+                # If it's not a known compatibility issue, re-raise
+                raise

--- a/src/controlnet_aux/zoe/zoedepth/models/zoedepth/zoedepth_v1.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/zoedepth/zoedepth_v1.py
@@ -33,6 +33,7 @@ from ..layers.dist_layers import ConditionalLogBinomial
 from ..layers.localbins_layers import (Projector, SeedBinRegressor,
                                             SeedBinRegressorUnnormed)
 from ..model_io import load_state_from_resource
+from ...models.base_models.midas_repo.midas.backbones.timm_adapter import is_new_timm
 
 
 class ZoeDepth(DepthModel):
@@ -248,3 +249,17 @@ class ZoeDepth(DepthModel):
     @staticmethod
     def build_from_config(config):
         return ZoeDepth.build(**config)
+
+    def load_state_dict(self, state_dict, strict=True):
+        """
+        Override load_state_dict to handle different model structure between timm versions
+        """
+        if is_new_timm:
+            # Filter out relative_position_index keys if using timm 1.0+
+            filtered_state_dict = {}
+            for k, v in state_dict.items():
+                if 'relative_position_index' not in k:
+                    filtered_state_dict[k] = v
+            return super().load_state_dict(filtered_state_dict, strict=False)
+        else:
+            return super().load_state_dict(state_dict, strict=strict)

--- a/src/controlnet_aux/zoe/zoedepth/models/zoedepth_nk/zoedepth_nk_v1.py
+++ b/src/controlnet_aux/zoe/zoedepth/models/zoedepth_nk/zoedepth_nk_v1.py
@@ -35,6 +35,7 @@ from ..layers.localbins_layers import (Projector, SeedBinRegressor,
                                             SeedBinRegressorUnnormed)
 from ..layers.patch_transformer import PatchTransformerEncoder
 from ..model_io import load_state_from_resource
+from ...models.base_models.midas_repo.midas.backbones.timm_adapter import is_new_timm
 
 class ZoeDepthNK(DepthModel):
     def __init__(self, core,  bin_conf, bin_centers_type="softplus", bin_embedding_dim=128,
@@ -330,3 +331,17 @@ class ZoeDepthNK(DepthModel):
     @staticmethod
     def build_from_config(config):
         return ZoeDepthNK.build(**config)
+
+    def load_state_dict(self, state_dict, strict=True):
+        """
+        Override load_state_dict to handle different model structure between timm versions
+        """
+        if is_new_timm:
+            # Filter out relative_position_index keys if using timm 1.0+
+            filtered_state_dict = {}
+            for k, v in state_dict.items():
+                if 'relative_position_index' not in k:
+                    filtered_state_dict[k] = v
+            return super().load_state_dict(filtered_state_dict, strict=False)
+        else:
+            return super().load_state_dict(state_dict, strict=strict)


### PR DESCRIPTION
1. Fix pidi device assignment

The PidiNet detector cannot run on any other GPU aside from GPU 0 due always initializing a specific tensor on the first available GPU.

Changing this line of code so that the tensor is created on the correct GPU fixes the issue and allows PidiNet to run on a device other than the primary GPU.

2. Fix for use with timm > 0.6.7

Fix ZoeDepth so that it works with timm > 0.6.7 as well as the older version

3. Fix dynamic relative imports in leres and pix2pix

Makes this code easier to vendor